### PR TITLE
Fixed bug: total amount of the invoices not showed in the archived orders table into the stored_orders block

### DIFF
--- a/gasistafelice/rest/templates/blocks/stored_orders/data.json
+++ b/gasistafelice/rest/templates/blocks/stored_orders/data.json
@@ -10,7 +10,7 @@
         "{{gso.tot_amount|escapejs|floatformat:"-2"}}",
         "{{gso.tot_gasmembers|escapejs}}",
         "&#8364; {{gso.tot_price|escapejs|floatformat:2}}",
-        "&#8364; {{gso.delivery_cost|escapejs|floatformat:2}}",
+        "&#8364; {{gso.invoice_amount|escapejs|floatformat:2}}",
         "&#8364; {{gso.tot_curtail|escapejs|floatformat:2}}",
         "{{gso.payment|escapejs}}",
         "{{gso.urn|escapejs}}",


### PR DESCRIPTION
Bug: wrong data retreived from db by stored_orders/data.json. 

Fix: turned the wrong line into the right one.
