### PR TITLE
Gas newsletter - order notifications

### DIFF
--- a/gasistafelice/admin/models.py
+++ b/gasistafelice/admin/models.py
@@ -163,8 +163,6 @@ class GASConfigAdmin(admin.ModelAdmin):
     form = GASConfigForm
     save_on_top = True
     list_display = ('gas', 'default_close_day', 'order_show_only_next_delivery', 'order_show_only_one_at_a_time', 'default_delivery_day','is_active')
-    #COMMENT MM: added notice_days_before_order_close to the form, now tech referrers can
-    #COMMENT MM: change the days count before which its GAS(es) is (are) notified of an o    #COMMENT MM: rder will close or delivered
     fieldsets = ((_("Configuration"), {
         'fields' : ('order_show_only_next_delivery', 'order_show_only_one_at_a_time', 
             'gasmember_auto_confirm_order', #KO by fero always True until Gasista Felice 2.0: 'auto_populate_products', 

--- a/gasistafelice/gas/management/commands/send_gas_notification.py
+++ b/gasistafelice/gas/management/commands/send_gas_notification.py
@@ -21,57 +21,58 @@ class Command(BaseCommand):
         try:
             for gas in GAS.objects.all():
                 delta_day = gas.config.notice_days_before_order_close
-                next_day = datetime.datetime.now()+datetime.timedelta(days=delta_day)
-                # print 'next_day: %s' % next_day
-                weeknumber = datetime.date.today().isocalendar()[1]
-                subject = "[NEWS] %s - %s (%s)" % (gas.id_in_des, gas, weeknumber)
+                if delta_day:
+                    next_day = datetime.datetime.now()+datetime.timedelta(days=delta_day)
+                    # print 'next_day: %s' % next_day
+                    weeknumber = datetime.date.today().isocalendar()[1]
+                    subject = "[NEWS] %s - %s (%s)" % (gas.id_in_des, gas, weeknumber)
 
-                if delta_day == 1:
-                    pre_msg = "Domani "
-                else:
-                    pre_msg = "Fra %d giorni " % delta_day
+                    if delta_day == 1:
+                        pre_msg = "Domani "
+                    else:
+                        pre_msg = "Fra %d giorni " % delta_day
 
-                _msg = []
-                g = gas.pk
-                # print gas
-                for order in gas.orders.open().filter(
-                        datetime_end__year = next_day.year, 
-                        datetime_end__month = next_day.month, 
-                        datetime_end__day = next_day.day
-                ):
-                    o = order.pk
-                    # print order
-                    _msg.append("* %s si chiude l'ordine %s\n" % (pre_msg, order))
-                    
-                    
-                # print 'next_day: %s' % next_day
-                # subject = "[NEWS] %s - %s (%s)" % (gas.id_in_des, gas, weeknumber)
-                if delta_day == 1:
-                    pre_msg = "Domani "
-                else:
-                   pre_msg = "Fra %d giorni " % delta_day
-                _delivery_msg = []
-                # g = gas.pk
-                # print gas
-                for order in gas.orders.closed().filter(
-                        delivery.date__year = next_day.year, 
-                        delivery.date__month = next_day.month, 
-                        delivery.date__day = next_day.day
-                ):
-                    o = order.pk
-                    # print order
-                    _delivery_msg.append("* %s si consegna l'ordine %s" % (pre_msg, order))
-                body = u""
-                if len(_msg) > 0:
-                    body = "Ordini in prossima chiusura\n\n"
-                    body +=  _msg.join("\n")
-                    
-                if len(_delivery_msg) > 0:
-                    body = "\nOrdini in prossima consegna\n\n"
-                    body +=  _delivery_msg.join("\n")
-                    
-                if body:
-                    gas.send_email_to_gasmembers(subject,body)
+                    _msg = []
+                    g = gas.pk
+                    # print gas
+                    for order in gas.orders.open().filter(
+                            datetime_end__year = next_day.year, 
+                            datetime_end__month = next_day.month, 
+                            datetime_end__day = next_day.day
+                    ):
+                        o = order.pk
+                        # print order
+                        _msg.append("* %s si chiude l'ordine %s\n" % (pre_msg, order))
+                        
+                        
+                    # print 'next_day: %s' % next_day
+                    # subject = "[NEWS] %s - %s (%s)" % (gas.id_in_des, gas, weeknumber)
+                    if delta_day == 1:
+                        pre_msg = "Domani "
+                    else:
+                       pre_msg = "Fra %d giorni " % delta_day
+                    _delivery_msg = []
+                    # g = gas.pk
+                    # print gas
+                    for order in gas.orders.closed().filter(
+                            delivery.date__year = next_day.year, 
+                            delivery.date__month = next_day.month, 
+                            delivery.date__day = next_day.day
+                    ):
+                        o = order.pk
+                        # print order
+                        _delivery_msg.append("* %s si consegna l'ordine %s" % (pre_msg, order))
+                    body = u""
+                    if len(_msg) > 0:
+                        body = "Ordini in prossima chiusura\n\n"
+                        body +=  _msg.join("\n")
+                        
+                    if len(_delivery_msg) > 0:
+                        body = "\nOrdini in prossima consegna\n\n"
+                        body +=  _delivery_msg.join("\n")
+                        
+                    if body:
+                        gas.send_email_to_gasmembers(subject,body)
 
 
         except Exception as e:


### PR DESCRIPTION
The tech referrers can change the days count before which the GAS members are notified when an order is closed or delivered. However, there is still the possibility for each GAS to decide wheter it wants to receive notification of the orders closure and delivery.
