### PR TITLE
Stock instead product name

### DIFF
--- a/gasistafelice/rest/views/blocks/basket.py
+++ b/gasistafelice/rest/views/blocks/basket.py
@@ -48,7 +48,7 @@ class Block(BlockSSDataTables):
 
         user_actions = []
 
-        if request.resource.gas.config.gasmember_auto_confirm_order:
+        if not request.resource.gas.config.gasmember_auto_confirm_order:
 
             #TODO seldon: does this work for a GASMember?
             #if request.user.has_perm(EDIT, obj=request.resource):
@@ -187,6 +187,7 @@ class Block(BlockSSDataTables):
             for gmo in self.resource.basket:
                 log.debug(u"Sto confermando un ordine gasista(%s)" % gmo)
                 gmo.confirm()
+                gmo.save()
 
             #IMPORTANT: unset args to compute table results!
             args = self.KW_DATA

--- a/gasistafelice/rest/views/blocks/order.py
+++ b/gasistafelice/rest/views/blocks/order.py
@@ -186,7 +186,7 @@ class Block(BlockSSDataTables):
             records.append({
                'id' : "%s %s %s %s" % (el.pk, form['id'], form['gsop_id'], form['ordered_price']),
                'supplier' : el.supplier,
-               'product' : el.product,
+               'product' : el.gasstock,
                'price' : el.gasstock.price,
                'ordered_amount' : form['ordered_amount'], #field inizializzato con il minimo amount e che ha l'attributo step
                'ordered_total' : total,


### PR DESCRIPTION
Changed the gas member order table, now the stock name is visualized instead of the product name.
