### PR TITLE
[LOGO] added supplier's icon url to catalog GDXP.

### DIFF
--- a/gasistafelice/gdxp/templates/gdxp/v0_2/supplier_info.xml
+++ b/gasistafelice/gdxp/templates/gdxp/v0_2/supplier_info.xml
@@ -40,6 +40,6 @@
                 {% endfor %}
             </contact>
         </contacts>
-        <logo>{{el.icon}}</logo>
+        <logo>{{el.icon_url}}</logo>
         <lastUpdate>{{el.last_update|timestamp}}</lastUpdate> 
 

--- a/gasistafelice/supplier/models.py
+++ b/gasistafelice/supplier/models.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.contrib.sites.models import Site
+#WAS: from django.contrib.sites.models import Site
 
 from flexi_auth.utils import register_parametric_role
 from flexi_auth.models import ParamRole
@@ -135,7 +135,8 @@ class Supplier(models.Model, PermissionResource):
 
     @property
     def icon_url(self):
-        domain = Site.objects.get_current().domain
+        #WAS: domain = Site.objects.get_current().domain
+        domain = settings.INIT_OPTIONS['domain']
         try:
             return u"%s%s" % (domain,self.logo.url or super(SUPPLIER, self).icon.url)
         except AttributeError:

--- a/gasistafelice/supplier/models.py
+++ b/gasistafelice/supplier/models.py
@@ -139,7 +139,7 @@ class Supplier(models.Model, PermissionResource):
         try:
             return u"%s%s" % (domain,self.logo.url or super(SUPPLIER, self).icon.url)
         except AttributeError:
-            return ""
+            return u""
 
     #-- Contacts --#
 

--- a/gasistafelice/supplier/models.py
+++ b/gasistafelice/supplier/models.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.dispatch import receiver
 from django.db.models.signals import post_save
+from django.contrib.sites.models import Site
 
 from flexi_auth.utils import register_parametric_role
 from flexi_auth.models import ParamRole
@@ -131,6 +132,14 @@ class Supplier(models.Model, PermissionResource):
     @property
     def icon(self):
         return self.logo or super(Supplier, self).icon
+
+    @property
+    def icon_url(self):
+        domain = Site.objects.get_current().domain
+        try:
+            return u"%s%s" % (domain,self.logo.url or super(SUPPLIER, self).icon.url)
+        except AttributeError:
+            return ""
 
     #-- Contacts --#
 


### PR DESCRIPTION
Now it is possible to export a GDXP with the supplier urls. 
These urls have to be accessible from the internet to make them usable in a catalogs aggregator.