### PR TITLE
Remove http force on NPM for UI dep installation

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -2,8 +2,6 @@ FROM iojs:2.5
 
 MAINTAINER Antonio Esposito "kobe@befair.it"
 
-RUN npm config set registry http://registry.npmjs.org/
-
 COPY deps/npm /code/ui/deps/npm
 RUN npm install -g $(cat /code/ui/deps/npm)
 


### PR DESCRIPTION
In the past NPM was forced to fetch packages using http instead of https for testing/debugging purposes. If the build on Travis CI passes we can restore the original configuration.